### PR TITLE
fix: 修复缓冲输出数组复用问题

### DIFF
--- a/src/main/java/org/hswebframework/reactor/excel/utils/StreamUtils.java
+++ b/src/main/java/org/hswebframework/reactor/excel/utils/StreamUtils.java
@@ -22,16 +22,12 @@ public class StreamUtils {
 
                 @Override
                 public void write(byte[] b, int off, int len) {
-                    if (len == b.length) {
-                        sink.next(b);
-                    } else {
-                        sink.next(Arrays.copyOfRange(b, off, off + len));
-                    }
+                    sink.next(Arrays.copyOfRange(b, off, off + len));
                 }
 
                 @Override
                 public void write(byte[] b) {
-                    sink.next(b);
+                    sink.next(Arrays.copyOf(b, b.length));
                 }
 
                 @Override

--- a/src/test/java/org/hswebframework/reactor/excel/utils/StreamUtilsTest.java
+++ b/src/test/java/org/hswebframework/reactor/excel/utils/StreamUtilsTest.java
@@ -1,0 +1,49 @@
+package org.hswebframework.reactor.excel.utils;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class StreamUtilsTest {
+
+    @Test
+    void bufferShouldKeepEmittedBytesStableUntilConsumed() {
+        int bufferSize = 64 * 1024;
+        int chunkSize = 8 * 1024;
+        byte[] expected = new byte[3 * bufferSize];
+        Arrays.fill(expected, 0, bufferSize, (byte) 1);
+        Arrays.fill(expected, bufferSize, 2 * bufferSize, (byte) 2);
+        Arrays.fill(expected, 2 * bufferSize, expected.length, (byte) 3);
+
+        List<byte[]> buffers = StreamUtils
+            .buffer(bufferSize, output -> Mono.fromRunnable(() -> {
+                try {
+                    for (int offset = 0; offset < expected.length; offset += chunkSize) {
+                        output.write(expected, offset, chunkSize);
+                    }
+                } catch (IOException error) {
+                    throw new UncheckedIOException(error);
+                } finally {
+                    StreamUtils.safeClose(output);
+                }
+            }))
+            .collectList()
+            .block();
+
+        assertNotNull(buffers);
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        for (byte[] buffer : buffers) {
+            actual.write(buffer, 0, buffer.length);
+        }
+
+        assertArrayEquals(expected, actual.toByteArray());
+    }
+}


### PR DESCRIPTION
## 变更说明

- 修复 `StreamUtils.buffer` 直接发送 `BufferedOutputStream` 内部数组导致后续写入覆盖已发送内容的问题。
- 输出 `byte[]` 前始终创建独立副本，保证异步或延迟消费时内容稳定。
- 新增确定性回归测试，覆盖连续写入三个 64KB 数据块后再消费输出的场景。

## 测试结果

- 命令：`zsh -lic 'java8 && mvn -Dtest=StreamUtilsTest#bufferShouldKeepEmittedBytesStableUntilConsumed test'`
- 单元测试：1 passed，0 failures，0 errors，0 skipped。
- `StreamUtils` 覆盖率：line 12/16（75.0%），instruction 43/53（81.1%）；无分支统计项。
- 集成测试：不适用，本次仅修复内存缓冲输出行为，不涉及数据库、消息、网络协议或外部服务。

## 影响与风险

- 每个输出块增加一次字节数组复制，换取异步消费场景下的数据正确性。
- 未修改公共 API、配置或文档结构。
- TraceHolder、MBean：不适用。
